### PR TITLE
Added Request Players method to SocketDev

### DIFF
--- a/lua/luadev/socketdev.lua
+++ b/lua/luadev/socketdev.lua
@@ -33,18 +33,22 @@ local methods = {
 	self = function( sock )
 		local who = sock:receive( "*l" )
 		luadev.RunOnSelf( sock:receive( "*a" ), who )
+		system.FlashWindow()
 	end,
 	sv = function( sock )
 		local who = sock:receive( "*l" )
 		luadev.RunOnServer( sock:receive( "*a" ), who )
+		system.FlashWindow()
 	end,
 	sh = function( sock )
 		local who = sock:receive( "*l" )
 		luadev.RunOnShared( sock:receive( "*a" ), who )
+		system.FlashWindow()
 	end,
 	cl = function( sock )
 		local who = sock:receive( "*l" )
 		luadev.RunOnClients( sock:receive( "*a" ), who )
+		system.FlashWindow()
 	end,
 	ent = function( sock )
 		local who = sock:receive( "*l" )
@@ -54,6 +58,7 @@ local methods = {
 			.. who:sub( 0, -5 )
 			.. "')"
 		luadev.RunOnShared( contents, who )
+		system.FlashWindow()
 	end,
 	client = function( sock )
 		local who = sock:receive( "*l" )
@@ -63,6 +68,7 @@ local methods = {
 				or player.GetByID( tonumber( to ) )
 			to = { to }
 		luadev.RunOnClient( sock:receive( "*a" ), to, who )
+		system.FlashWindow()
 	end,
 }
 
@@ -73,8 +79,6 @@ SOCKETDEV:SetSize(0, 0)
 SOCKETDEV.Think = function()
 	local cl, a, b, c = sock:accept()
 	if cl then
-		system.FlashWindow()
-
 		if cl:getpeername() ~= "127.0.0.1" then
 			print("Refused", cl:getpeername())
 			cl:shutdown()

--- a/lua/luadev/socketdev.lua
+++ b/lua/luadev/socketdev.lua
@@ -70,6 +70,14 @@ local methods = {
 		luadev.RunOnClient( sock:receive( "*a" ), to, who )
 		system.FlashWindow()
 	end,
+	requestPlayers = function( sock )
+		local plys = {}
+		for _, ply in next, player.GetAll() do
+			table.insert( plys, ply:Nick() )
+		end
+
+		sock:send( table.concat( plys, "\n" ) )
+	end
 }
 
 SOCKETDEV = vgui.Create("Panel")

--- a/lua/luadev/socketdev.lua
+++ b/lua/luadev/socketdev.lua
@@ -30,15 +30,40 @@ sock:settimeout(0)
 assert(sock:listen(0))
 	
 local methods = {
-	self = luadev.RunOnSelf,
-	sv = luadev.RunOnServer,
-	sh = luadev.RunOnShared,
-	cl = luadev.RunOnClients,
-	ent = function(contents, who)
-		contents = "ENT = {}; local ENT=ENT; " .. contents .. "; scripted_ents.Register(ENT, '" .. who:sub(0, -5) .. "')"
-		luadev.RunOnShared(contents, who)
+	self = function( sock )
+		local who = sock:receive( "*l" )
+		luadev.RunOnSelf( sock:receive( "*a" ), who )
 	end,
-	client = luadev.RunOnClient,
+	sv = function( sock )
+		local who = sock:receive( "*l" )
+		luadev.RunOnServer( sock:receive( "*a" ), who )
+	end,
+	sh = function( sock )
+		local who = sock:receive( "*l" )
+		luadev.RunOnShared( sock:receive( "*a" ), who )
+	end,
+	cl = function( sock )
+		local who = sock:receive( "*l" )
+		luadev.RunOnClients( sock:receive( "*a" ), who )
+	end,
+	ent = function( sock )
+		local who = sock:receive( "*l" )
+		local contents = "ENT = {}; local ENT=ENT; "
+			.. sock:receive( "*a" )
+			.. "; scripted_ents.Register(ENT, '"
+			.. who:sub( 0, -5 )
+			.. "')"
+		luadev.RunOnShared( contents, who )
+	end,
+	client = function( sock )
+		local who = sock:receive( "*l" )
+		local to = sock:receive( "*l" )
+			to = easylua
+				and easylua.FindEntity( to )
+				or player.GetByID( tonumber( to ) )
+			to = { to }
+		luadev.RunOnClient( sock:receive( "*a" ), to, who )
+	end,
 }
 
 SOCKETDEV = vgui.Create("Panel")
@@ -59,17 +84,9 @@ SOCKETDEV.Think = function()
 		cl:settimeout(0)
 
 		local method = cl:receive("*l")
-		local who = cl:receive("*l")
 
 		if method and methods[method] then
-			if method == "client" then
-				local to = cl:receive("*l")
-				local contents = cl:receive("*a")
-				methods[method](contents, {easylua and easylua.FindEntity(to) or player.GetByID(tonumber(to))}, who)
-			else
-				local contents = cl:receive("*a")
-				methods[method](contents, who)
-			end
+			methods[ method ]( cl )
 		end
 		cl:shutdown()
 	end

--- a/lua/luadev/socketdev.lua
+++ b/lua/luadev/socketdev.lua
@@ -28,7 +28,7 @@ local sock = socket.tcp()
 assert(sock:bind("127.0.0.1", 27099))
 sock:settimeout(0)
 assert(sock:listen(0))
-	
+
 local methods = {
 	self = function( sock )
 		local who = sock:receive( "*l" )


### PR DESCRIPTION
Adds a new method to poll SocketDev for; `requestPlayers`.

Returns a newline-delimited list of player names to make external tools easier to select players.

This PR also abstracts SocketDev functions by passing the socket directly to them, which'll allow for more varied types of methods in the future. e.g. JSON, Batch, etc.